### PR TITLE
Add Jeremy Stokes portfolio features

### DIFF
--- a/apps/jeremy-stokes/e2e/features.spec.ts
+++ b/apps/jeremy-stokes/e2e/features.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect } from '@playwright/test'
+
+const baseURL = 'http://localhost:5174'
+
+test.beforeEach(async ({ page }) => {
+  await page.goto(baseURL)
+})
+
+test('hero section renders', async ({ page }) => {
+  await expect(page.locator('h1')).toHaveText('Jeremy Stokes')
+})
+
+test('project cards render and are interactive', async ({ page, context }) => {
+  const cards = page.locator('.projectCard')
+  await expect(cards).toHaveCount(3)
+
+  const first = cards.nth(0)
+  const initialTransform = await first.evaluate(
+    (el) => getComputedStyle(el).transform
+  )
+  await first.hover()
+  const hoveredTransform = await first.evaluate(
+    (el) => getComputedStyle(el).transform
+  )
+  expect(hoveredTransform).not.toBe(initialTransform)
+
+  const cookbookCard = cards.filter({ hasText: 'Portfolio Cookbook' })
+  const [newPage] = await Promise.all([
+    context.waitForEvent('page'),
+    cookbookCard.click(),
+  ])
+  await newPage.waitForLoadState()
+  expect(newPage.url()).toContain('jeremystokes.gumroad.com')
+  await newPage.close()
+})
+
+test('about me section appears on scroll', async ({ page }) => {
+  const about = page.locator('#about')
+  await about.scrollIntoViewIfNeeded()
+  await expect(about).toBeVisible()
+})
+
+test('contact cta has mail link', async ({ page }) => {
+  const link = page.locator('a[href^="mailto:"]')
+  await expect(link).toBeVisible()
+})
+
+test('grid responsive on mobile', async ({ page }) => {
+  await page.setViewportSize({ width: 375, height: 640 })
+  const columns = await page
+    .locator('.grid')
+    .evaluate(
+      (el) => getComputedStyle(el).gridTemplateColumns.split(' ').length
+    )
+  expect(columns).toBe(1)
+})

--- a/apps/jeremy-stokes/index.html
+++ b/apps/jeremy-stokes/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Jeremy Stokes Portfolio</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/jeremy-stokes/package.json
+++ b/apps/jeremy-stokes/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "robin-noguier",
+  "name": "jeremy-stokes",
   "version": "1.0.0",
   "type": "module",
   "private": true,
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "APP=robin-noguier playwright test",
+    "test": "APP=jeremy-stokes playwright test",
+    "test:e2e": "APP=jeremy-stokes playwright test",
     "lint": "eslint src",
     "typecheck": "tsc --noEmit"
   }

--- a/apps/jeremy-stokes/src/App.tsx
+++ b/apps/jeremy-stokes/src/App.tsx
@@ -1,0 +1,23 @@
+import HeroSectionBoldTypography from './features/hero-section-bold-typography/HeroSectionBoldTypography'
+import ProjectShowcaseGrid from './features/project-showcase-grid-list/ProjectShowcaseGrid'
+import AboutMeSection from './features/embedded-about-me-section/AboutMeSection'
+import ScrollAppearEffect from './features/subtle-scroll-animations-appear/ScrollAppearEffect'
+import ContactCTA from './features/contact-call-to-action/ContactCTA'
+import ResponsiveLayoutWrapper from './features/responsive-layout-wrapper/ResponsiveLayoutWrapper'
+
+function App() {
+  return (
+    <ResponsiveLayoutWrapper>
+      <HeroSectionBoldTypography />
+      <ScrollAppearEffect>
+        <ProjectShowcaseGrid />
+      </ScrollAppearEffect>
+      <ScrollAppearEffect>
+        <AboutMeSection />
+      </ScrollAppearEffect>
+      <ContactCTA />
+    </ResponsiveLayoutWrapper>
+  )
+}
+
+export default App

--- a/apps/jeremy-stokes/src/features/contact-call-to-action/ContactCTA.tsx
+++ b/apps/jeremy-stokes/src/features/contact-call-to-action/ContactCTA.tsx
@@ -1,0 +1,12 @@
+import styles from './styles.module.css'
+
+const ContactCTA = () => (
+  <section className={styles.cta}>
+    <h2 className={styles.title}>Get in Touch</h2>
+    <a className={styles.link} href="mailto:hello@jeremystokes.com">
+      hello@jeremystokes.com
+    </a>
+  </section>
+)
+
+export default ContactCTA

--- a/apps/jeremy-stokes/src/features/contact-call-to-action/styles.module.css
+++ b/apps/jeremy-stokes/src/features/contact-call-to-action/styles.module.css
@@ -1,0 +1,21 @@
+.cta {
+  padding: 4rem 1rem;
+  text-align: center;
+  background: #f5f5f5;
+}
+
+.title {
+  font-size: 2rem;
+  margin-bottom: 1rem;
+  color: #333;
+}
+
+.link {
+  font-size: 1.2rem;
+  color: #007bff;
+  text-decoration: none;
+}
+
+.link:hover {
+  text-decoration: underline;
+}

--- a/apps/jeremy-stokes/src/features/embedded-about-me-section/AboutMeSection.tsx
+++ b/apps/jeremy-stokes/src/features/embedded-about-me-section/AboutMeSection.tsx
@@ -1,0 +1,13 @@
+import styles from './styles.module.css'
+
+const AboutMeSection = () => (
+  <section className={styles.about} id="about">
+    <h2 className={styles.title}>About Me</h2>
+    <p className={styles.text}>
+      I'm Jeremy, a product designer who loves video games and cartoons. I build
+      delightful user experiences and love experimenting with new tech.
+    </p>
+  </section>
+)
+
+export default AboutMeSection

--- a/apps/jeremy-stokes/src/features/embedded-about-me-section/styles.module.css
+++ b/apps/jeremy-stokes/src/features/embedded-about-me-section/styles.module.css
@@ -1,0 +1,18 @@
+.about {
+  padding: 4rem 1rem;
+  max-width: 800px;
+  margin: 0 auto;
+  text-align: center;
+}
+
+.title {
+  font-size: 2rem;
+  margin-bottom: 1rem;
+  color: #333;
+}
+
+.text {
+  font-size: 1.1rem;
+  color: #444;
+  line-height: 1.6;
+}

--- a/apps/jeremy-stokes/src/features/hero-section-bold-typography/HeroSectionBoldTypography.tsx
+++ b/apps/jeremy-stokes/src/features/hero-section-bold-typography/HeroSectionBoldTypography.tsx
@@ -1,0 +1,25 @@
+import { motion } from 'framer-motion'
+import styles from './styles.module.css'
+
+const HeroSectionBoldTypography = () => (
+  <section className={styles.hero}>
+    <motion.h1
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.6 }}
+      className={styles.title}
+    >
+      Jeremy Stokes
+    </motion.h1>
+    <motion.p
+      initial={{ opacity: 0, y: 10 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ delay: 0.2, duration: 0.5 }}
+      className={styles.subtitle}
+    >
+      Product Designer &amp; Developer
+    </motion.p>
+  </section>
+)
+
+export default HeroSectionBoldTypography

--- a/apps/jeremy-stokes/src/features/hero-section-bold-typography/styles.module.css
+++ b/apps/jeremy-stokes/src/features/hero-section-bold-typography/styles.module.css
@@ -1,0 +1,26 @@
+.hero {
+  padding: 6rem 1rem 4rem;
+  text-align: center;
+}
+
+.title {
+  font-size: 3rem;
+  font-weight: 900;
+  letter-spacing: -1px;
+  color: #222;
+}
+
+.subtitle {
+  font-size: 1.25rem;
+  margin-top: 0.5rem;
+  color: #555;
+}
+
+@media (min-width: 768px) {
+  .title {
+    font-size: 4rem;
+  }
+  .subtitle {
+    font-size: 1.5rem;
+  }
+}

--- a/apps/jeremy-stokes/src/features/interactive-project-item/InteractiveProjectItem.tsx
+++ b/apps/jeremy-stokes/src/features/interactive-project-item/InteractiveProjectItem.tsx
@@ -1,0 +1,15 @@
+import { motion } from 'framer-motion'
+import { PropsWithChildren } from 'react'
+import styles from './styles.module.css'
+
+const InteractiveProjectItem = ({ children }: PropsWithChildren) => (
+  <motion.div
+    className={styles.wrapper}
+    whileHover={{ scale: 1.03 }}
+    whileTap={{ scale: 0.98 }}
+  >
+    {children}
+  </motion.div>
+)
+
+export default InteractiveProjectItem

--- a/apps/jeremy-stokes/src/features/interactive-project-item/styles.module.css
+++ b/apps/jeremy-stokes/src/features/interactive-project-item/styles.module.css
@@ -1,0 +1,4 @@
+.wrapper {
+  display: inline-block;
+  cursor: pointer;
+}

--- a/apps/jeremy-stokes/src/features/project-showcase-grid-list/ProjectCard.tsx
+++ b/apps/jeremy-stokes/src/features/project-showcase-grid-list/ProjectCard.tsx
@@ -1,0 +1,60 @@
+import { motion } from 'framer-motion'
+import styles from './styles.module.css'
+import type { Project } from './ProjectShowcaseGrid'
+
+const cardVariants = {
+  hidden: { opacity: 0, y: 20 },
+  visible: {
+    opacity: 1,
+    y: 0,
+    transition: { type: 'spring', stiffness: 100, damping: 12 },
+  },
+}
+
+const hoverEffect = { scale: 1.03, boxShadow: '0px 8px 20px rgba(0,0,0,0.12)' }
+
+const ProjectCard = ({ project }: { project: Project }) => {
+  const { title, category, imageUrl, description, detailsLink } = project
+
+  const handleCardClick = () => {
+    if (detailsLink) {
+      if (detailsLink.startsWith('http')) {
+        window.open(detailsLink, '_blank', 'noopener,noreferrer')
+      } else {
+        window.location.href = detailsLink
+      }
+    }
+  }
+
+  return (
+    <motion.div
+      className={styles.projectCard}
+      variants={cardVariants}
+      whileHover={hoverEffect}
+      onClick={handleCardClick}
+      tabIndex={0}
+      onKeyPress={(e) =>
+        (e.key === 'Enter' || e.key === ' ') && handleCardClick()
+      }
+      role="link"
+      aria-label={`View details for project: ${title}`}
+    >
+      {imageUrl && (
+        <img
+          src={imageUrl}
+          alt={`${title} screenshot`}
+          className={styles.projectImage}
+        />
+      )}
+      <div className={styles.cardContent}>
+        <h3 className={styles.projectTitle}>{title}</h3>
+        {category && <p className={styles.projectCategory}>{category}</p>}
+        {description && (
+          <p className={styles.projectDescription}>{description}</p>
+        )}
+      </div>
+    </motion.div>
+  )
+}
+
+export default ProjectCard

--- a/apps/jeremy-stokes/src/features/project-showcase-grid-list/ProjectShowcaseGrid.tsx
+++ b/apps/jeremy-stokes/src/features/project-showcase-grid-list/ProjectShowcaseGrid.tsx
@@ -1,0 +1,74 @@
+import ProjectCard from './ProjectCard'
+import InteractiveProjectItem from '../interactive-project-item/InteractiveProjectItem'
+import styles from './styles.module.css'
+import { motion } from 'framer-motion'
+
+export interface Project {
+  id: string
+  title: string
+  category?: string
+  imageUrl?: string
+  description?: string
+  tldrLink?: string
+  detailsLink?: string
+}
+
+const projectsData: Project[] = [
+  {
+    id: 'petlove-quiz',
+    title: 'Petlove Quiz',
+    category: 'Freelance',
+    imageUrl: 'https://via.placeholder.com/300x200',
+    description: 'Quiz platform for pet lovers.',
+    detailsLink: 'https://example.com/petlove',
+  },
+  {
+    id: 'duolingo-courses',
+    title: 'Duolingo Courses',
+    category: 'Duolingo',
+    imageUrl: 'https://via.placeholder.com/300x200',
+    description: 'UI work for language courses.',
+    detailsLink: 'https://example.com/duolingo',
+  },
+  {
+    id: 'portfolio-cookbook',
+    title: 'Portfolio Cookbook',
+    category: 'Instagram',
+    imageUrl: 'https://via.placeholder.com/300x200',
+    description: 'Digital cookbook resource.',
+    detailsLink: 'https://jeremystokes.gumroad.com',
+  },
+]
+
+const containerVariants = {
+  hidden: { opacity: 0 },
+  visible: {
+    opacity: 1,
+    transition: {
+      staggerChildren: 0.1,
+    },
+  },
+}
+
+const ProjectShowcaseGrid = () => (
+  <motion.section
+    className={styles.projectGridContainer}
+    variants={containerVariants}
+    initial="hidden"
+    animate="visible"
+    aria-labelledby="project-showcase-title"
+  >
+    <h2 id="project-showcase-title" className={styles.showcaseTitle}>
+      What I’ve been up to recently...
+    </h2>
+    <div className={styles.grid}>
+      {projectsData.map((project) => (
+        <InteractiveProjectItem key={project.id}>
+          <ProjectCard project={project} />
+        </InteractiveProjectItem>
+      ))}
+    </div>
+  </motion.section>
+)
+
+export default ProjectShowcaseGrid

--- a/apps/jeremy-stokes/src/features/project-showcase-grid-list/styles.module.css
+++ b/apps/jeremy-stokes/src/features/project-showcase-grid-list/styles.module.css
@@ -1,0 +1,69 @@
+.projectGridContainer {
+  padding: 2rem 1rem;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.showcaseTitle {
+  font-size: 2rem;
+  font-weight: bold;
+  margin-bottom: 2rem;
+  text-align: center;
+  color: #333;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 2rem;
+}
+
+.projectCard {
+  background-color: #fff;
+  border-radius: 8px;
+  box-shadow: 0px 4px 15px rgba(0, 0, 0, 0.08);
+  overflow: hidden;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  text-decoration: none;
+  color: inherit;
+}
+
+.projectCard:focus {
+  outline: 2px solid #007bff;
+  outline-offset: 2px;
+}
+
+.projectImage {
+  width: 100%;
+  height: 200px;
+  object-fit: cover;
+}
+
+.cardContent {
+  padding: 1rem 1.5rem;
+  flex-grow: 1;
+}
+
+.projectTitle {
+  font-size: 1.25rem;
+  font-weight: bold;
+  margin-bottom: 0.5rem;
+  color: #222;
+}
+
+.projectCategory {
+  font-size: 0.875rem;
+  color: #555;
+  margin-bottom: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.projectDescription {
+  font-size: 1rem;
+  color: #444;
+  line-height: 1.5;
+  margin-bottom: 1rem;
+}

--- a/apps/jeremy-stokes/src/features/responsive-layout-wrapper/ResponsiveLayoutWrapper.tsx
+++ b/apps/jeremy-stokes/src/features/responsive-layout-wrapper/ResponsiveLayoutWrapper.tsx
@@ -1,0 +1,8 @@
+import { PropsWithChildren } from 'react'
+import styles from './styles.module.css'
+
+const ResponsiveLayoutWrapper = ({ children }: PropsWithChildren) => (
+  <div className={styles.container}>{children}</div>
+)
+
+export default ResponsiveLayoutWrapper

--- a/apps/jeremy-stokes/src/features/responsive-layout-wrapper/styles.module.css
+++ b/apps/jeremy-stokes/src/features/responsive-layout-wrapper/styles.module.css
@@ -1,0 +1,15 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.container > * {
+  width: 100%;
+}
+
+@media (min-width: 768px) {
+  .container {
+    padding: 0 2rem;
+  }
+}

--- a/apps/jeremy-stokes/src/features/subtle-scroll-animations-appear/ScrollAppearEffect.tsx
+++ b/apps/jeremy-stokes/src/features/subtle-scroll-animations-appear/ScrollAppearEffect.tsx
@@ -1,0 +1,29 @@
+import { motion, useAnimation } from 'framer-motion'
+import { useInView } from 'react-intersection-observer'
+import { PropsWithChildren, useEffect } from 'react'
+
+const ScrollAppearEffect = ({ children }: PropsWithChildren) => {
+  const controls = useAnimation()
+  const [ref, inView] = useInView({ triggerOnce: true, margin: '-50px' })
+
+  useEffect(() => {
+    if (inView) controls.start('visible')
+  }, [controls, inView])
+
+  return (
+    <motion.div
+      ref={ref}
+      initial="hidden"
+      animate={controls}
+      variants={{
+        hidden: { opacity: 0, y: 30 },
+        visible: { opacity: 1, y: 0 },
+      }}
+      transition={{ duration: 0.6 }}
+    >
+      {children}
+    </motion.div>
+  )
+}
+
+export default ScrollAppearEffect

--- a/apps/jeremy-stokes/src/index.css
+++ b/apps/jeremy-stokes/src/index.css
@@ -1,0 +1,12 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto',
+    sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}

--- a/apps/jeremy-stokes/src/main.tsx
+++ b/apps/jeremy-stokes/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App'
+import './index.css'
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+)

--- a/apps/jeremy-stokes/tsconfig.json
+++ b/apps/jeremy-stokes/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "react"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/apps/jeremy-stokes/tsconfig.node.json
+++ b/apps/jeremy-stokes/tsconfig.node.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/apps/jeremy-stokes/vite.config.ts
+++ b/apps/jeremy-stokes/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5174,
+    host: true,
+  },
+})

--- a/apps/robin-noguier/e2e/basic.spec.ts
+++ b/apps/robin-noguier/e2e/basic.spec.ts
@@ -1,0 +1,8 @@
+import { test, expect } from '@playwright/test'
+
+const baseURL = 'http://localhost:5173'
+
+test('renders heading', async ({ page }) => {
+  await page.goto(baseURL)
+  await expect(page.locator('h1')).toHaveText('Portfolio Monorepo')
+})

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "scripts": {
     "dev": "turbo run dev",
     "dev:robin": "turbo run dev --filter=robin-noguier",
+    "dev:jeremy": "turbo run dev --filter=jeremy-stokes",
     "build": "turbo run build",
     "test": "turbo run test",
     "test:e2e": "turbo run test:e2e",
@@ -40,7 +41,8 @@
     "framer-motion": "11.0.24",
     "lenis": "1.3.4",
     "lodash": "4.17.21",
-    "papaparse": "5.4.1"
+    "papaparse": "5.4.1",
+    "react-intersection-observer": "9.4.3"
   },
   "devDependencies": {
     "@playwright/test": "1.52.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig, devices } from '@playwright/test'
+
+const app = process.env.APP || process.env.app || process.env.npm_config_app
+const port = app === 'jeremy-stokes' ? 5174 : 5173
+
+export default defineConfig({
+  testDir: `apps/${app ?? 'jeremy-stokes'}/e2e`,
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: [['html', { outputFolder: 'playwright-report' }]],
+  use: {
+    baseURL: `http://localhost:${port}`,
+    trace: 'on-first-retry',
+  },
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+  webServer: {
+    command: `pnpm --filter=${app ?? 'jeremy-stokes'} dev`,
+    port,
+    reuseExistingServer: !process.env.CI,
+  },
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,5 +11,8 @@
     "esModuleInterop": true,
     "resolveJsonModule": true
   },
-  "references": [{ "path": "./apps/robin-noguier" }]
+  "references": [
+    { "path": "./apps/robin-noguier" },
+    { "path": "./apps/jeremy-stokes" }
+  ]
 }


### PR DESCRIPTION
## Summary
- scaffold Jeremy Stokes app with Vite
- implement hero section, project grid, about me, contact CTA and scroll effects
- add responsive layout wrapper and interactive project item
- add Playwright tests for Jeremy Stokes app
- set up Playwright configuration and scripts
- add minimal test for Robin Noguier app

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Playwright browsers not installed)*

------
https://chatgpt.com/codex/tasks/task_b_683a6b0aa338832091930e64d9c9f5dd